### PR TITLE
Handle full SQLite db for sqlite::Ntuple

### DIFF
--- a/art_root_io/RootInputFile.cc
+++ b/art_root_io/RootInputFile.cc
@@ -353,9 +353,8 @@ namespace art {
     }
     // Also need to check RootFileDB if we have one.
     if (fileFormatVersion_.value_ >= 5) {
-      sqliteDB_ =
-        ServiceHandle<DatabaseConnection>()->get<TKeyVFSOpenPolicy>(
-          "RootFileDB", filePtr_.get());
+      sqliteDB_ = ServiceHandle<DatabaseConnection>()->get<TKeyVFSOpenPolicy>(
+        "RootFileDB", filePtr_.get());
       if (readIncomingParameterSets &&
           have_table(*sqliteDB_, "ParameterSets", fileName_)) {
         fhicl::ParameterSetRegistry::importFrom(*sqliteDB_);

--- a/art_root_io/RootInputFile.cc
+++ b/art_root_io/RootInputFile.cc
@@ -353,9 +353,9 @@ namespace art {
     }
     // Also need to check RootFileDB if we have one.
     if (fileFormatVersion_.value_ >= 5) {
-      sqliteDB_.reset(
+      sqliteDB_ =
         ServiceHandle<DatabaseConnection>()->get<TKeyVFSOpenPolicy>(
-          "RootFileDB", filePtr_.get()));
+          "RootFileDB", filePtr_.get());
       if (readIncomingParameterSets &&
           have_table(*sqliteDB_, "ParameterSets", fileName_)) {
         fhicl::ParameterSetRegistry::importFrom(*sqliteDB_);

--- a/art_root_io/RootOutputFile.cc
+++ b/art_root_io/RootOutputFile.cc
@@ -377,10 +377,11 @@ namespace art {
                                   splitLevel,
                                   treeMaxVirtualSize,
                                   saveMemoryObjectThreshold);
-    rootFileDB_ = ServiceHandle<DatabaseConnection> {
-    } -> get<TKeyVFSOpenPolicy>("RootFileDB",
-                                filePtr_.get(),
-                                SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE);
+    rootFileDB_ = ServiceHandle<DatabaseConnection>
+    {
+      } -> get<TKeyVFSOpenPolicy>("RootFileDB",
+                                  filePtr_.get(),
+                                  SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE);
     beginTime_ = std::chrono::steady_clock::now();
     // Check that dictionaries for the auxiliaries exist
     root::DictionaryChecker checker;

--- a/art_root_io/RootOutputFile.cc
+++ b/art_root_io/RootOutputFile.cc
@@ -377,10 +377,10 @@ namespace art {
                                   splitLevel,
                                   treeMaxVirtualSize,
                                   saveMemoryObjectThreshold);
-    rootFileDB_.reset(ServiceHandle<DatabaseConnection> {
+    rootFileDB_ = ServiceHandle<DatabaseConnection> {
     } -> get<TKeyVFSOpenPolicy>("RootFileDB",
                                 filePtr_.get(),
-                                SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE));
+                                SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE);
     beginTime_ = std::chrono::steady_clock::now();
     // Check that dictionaries for the auxiliaries exist
     root::DictionaryChecker checker;

--- a/art_root_io/detail/SamplingInputFile.h
+++ b/art_root_io/detail/SamplingInputFile.h
@@ -95,7 +95,8 @@ namespace art {
       double const weight_;
       double const probability_;
       EventID const firstEvent_;
-      std::unique_ptr<cet::sqlite::Connection> sqliteDB_; // start with invalid connection
+      std::unique_ptr<cet::sqlite::Connection>
+        sqliteDB_; // start with invalid connection
       int64_t saveMemoryObjectThreshold_;
       FileIndex fileIndex_{};
       FileFormatVersion fileFormatVersion_{};

--- a/art_root_io/detail/SamplingInputFile.h
+++ b/art_root_io/detail/SamplingInputFile.h
@@ -95,8 +95,7 @@ namespace art {
       double const weight_;
       double const probability_;
       EventID const firstEvent_;
-      cet::sqlite::Connection* sqliteDB_{
-        nullptr}; // Start with invalid connection.
+      std::unique_ptr<cet::sqlite::Connection> sqliteDB_; // start with invalid connection
       int64_t saveMemoryObjectThreshold_;
       FileIndex fileIndex_{};
       FileFormatVersion fileFormatVersion_{};


### PR DESCRIPTION
Make it so that filling the database is not an error. Inserts and flushes of Ntuple become no-ops when a db becomes full.